### PR TITLE
Update interface for example01

### DIFF
--- a/examples/chaincode/go/chaincode_example01/chaincode_example01.go
+++ b/examples/chaincode/go/chaincode_example01/chaincode_example01.go
@@ -33,9 +33,9 @@ var Aval, Bval, X int
 
 // Init callback representing the invocation of a chaincode
 // This chaincode will manage two accounts A and B and will transfer X units from A to B upon invoke
-func (t *SimpleChaincode) Init(stub shim.ChaincodeStubInterface, function string, args []string) ([]byte, error) {
+func (t *SimpleChaincode) Init(stub shim.ChaincodeStubInterface) ([]byte, error) {
 	var err error
-
+	_, args := stub.GetFunctionAndParameters()
 	if len(args) != 4 {
 		return nil, errors.New("Incorrect number of arguments. Expecting 4")
 	}
@@ -69,7 +69,8 @@ func (t *SimpleChaincode) Init(stub shim.ChaincodeStubInterface, function string
 	return nil, nil
 }
 
-func (t *SimpleChaincode) Invoke(stub shim.ChaincodeStubInterface, function string, args []string) ([]byte, error) {
+func (t *SimpleChaincode) Invoke(stub shim.ChaincodeStubInterface) ([]byte, error) {
+	_, args := stub.GetFunctionAndParameters()
 	// Transaction makes payment of X units from A to B
 	var err error
 	X, err = strconv.Atoi(args[0])
@@ -84,7 +85,7 @@ func (t *SimpleChaincode) Invoke(stub shim.ChaincodeStubInterface, function stri
 }
 
 // Query callback representing the query of a chaincode
-func (t *SimpleChaincode) Query(stub shim.ChaincodeStubInterface, function string, args []string) ([]byte, error) {
+func (t *SimpleChaincode) Query(stub shim.ChaincodeStubInterface) ([]byte, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
This commit updates example01 using the new chaincode
interface where only a stub is passed as an argument.

Signed-off-by: Gabor Hosszu <gabor@digitalasset.com>